### PR TITLE
Add submodules file for VDKQueue

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "mac/Blink1Control/VDKQueue"]
+    path = mac/Blink1Control/VDKQueue
+    url = https://github.com/bdkjones/VDKQueue.git


### PR DESCRIPTION
Currently theres no submodule mapping for VDKQueue, this fixes that, but Ive also provided an alternative method which fix VDKqueue by not actually using submodules but putting the code directly into source. #3
