### PR TITLE
Add SIGTERM to signal trapping

### DIFF
--- a/linux/contrib/blink1-webcam-busylight.sh
+++ b/linux/contrib/blink1-webcam-busylight.sh
@@ -63,16 +63,16 @@ BUSY=0
 # Start out as being available/free
 $TOOL --rgb $COLOR_FREE > /dev/null 2>&1
 
-#signal trapping
-CTRL_c()
-# run if user hits CTRL-c
+##signal trapping
+cleanup()
 {
     # Turn the Blink(1) off
     $TOOL --off > /dev/null 2>&1
     exit $?
 }
-# trap keyboard interrupt (CTRL-c)
-trap CTRL_c SIGINT
+# trap keyboard interrupt (CTRL-c) or a SIGTERM (kill)
+trap cleanup SIGINT SIGTERM
+
 
 #infinite loop, stop with CTRL-c
 while true; do

--- a/linux/contrib/gmail-to-blink1.sh
+++ b/linux/contrib/gmail-to-blink1.sh
@@ -153,16 +153,14 @@ function show_help
 
 
 ##signal trapping
-CTRL_c()
-## run if user hits CTRL-c
+cleanup()
 {
     # Turn the Blink(1) off
-    led_off
-    rm --force $GMAILOUT
+    $TOOL --off > /dev/null 2>&1
     exit $?
 }
-# trap keyboard interrupt (CTRL-c)
-trap CTRL_c SIGINT
+# trap keyboard interrupt (CTRL-c) or a SIGTERM (kill)
+trap cleanup SIGINT SIGTERM
 
 
 ################


### PR DESCRIPTION
The more I thought about it, the more it made sense to treat a
SIGTERM the same way as the user pressing CTRL-c (i.e. the blink1
LED should be turned off)

So this is a slight amendment of the other two bash scripts I sent
over that you've already merged in
