### PR TITLE
Fix FreeBSD build of blink1-tool

### DIFF
--- a/commandline/Makefile
+++ b/commandline/Makefile
@@ -134,11 +134,12 @@ endif
 ifeq "$(OS)" "freebsd"
 LIBTARGET = blink1-lib.so
 #LIBTARGET = libBlink1.so
-LIBS   += -L/usr/local/lib -lusb -lrt -lpthread -liconv -static
+LIBS   += -L/usr/local/lib -lusb -lrt -lpthread -liconv
 OBJS = ./hidapi/libusb/hid.o
 EXEFLAGS=
 LIBFLAGS = -shared -o $(LIBTARGET) $(LIBS)
 EXE=
+CFLAGS+= -I/usr/local/include -fPIC
 endif
 
 


### PR DESCRIPTION
libiconv header files live in /usr/local/include. Add this directory to the list
of directories to be searched for headers.

Also tweak some other flags which break the build (at least on my FreeBSD 9.1
machine).
