### PR TITLE
Added the white-point correction feature

### DIFF
--- a/python/pypi/README.md
+++ b/python/pypi/README.md
@@ -65,3 +65,34 @@ The context manager supports a ''gamma'' argument which allows you to supply a p
 This example provides a gamma correction of 2 to each of the three colour channels. 
         
 Higher values of gamma make the blink(1) appear more colorful but decrease the brightness of colours. 
+
+White point correction
+----------------------
+
+The human eye's perception of color can be influenced by ambient lighting. In some circumstances it may be desirable
+to apply a small colour correction in order to make colors appear more accurate. For example, if we were operating
+the blink(1) in a room lit predimenantly by candle-light:
+
+    with blink1(white_point='candle', switch_off) as b1:
+        b1.fade_to_color(100, 'white')
+
+Viewed in daylight this would make the Blink(1) appear yellowish, hoever in a candle-lit room this would be perceived
+as a more natural white. If we did not apply this kind of color correction the Blink(1) would appear blueish.
+
+The following values are acceptable white-points:
+
+* Any triple of (r,g,b). Each 0 <= luminance <= 255
+* Any color_temperature expressed as an integer or float in Kelvin
+* A color temperature name.
+
+The library supports the following temperature names:
+
+* candle
+* sunrise
+* incandescent
+* tungsten
+* halogen
+* sunlight
+* overcast
+* shade
+* blue-sky

--- a/python/pypi/blink1/kelvin.py
+++ b/python/pypi/blink1/kelvin.py
@@ -1,0 +1,64 @@
+"""
+Python implementation of Tanner Helland's color color conversion code.
+http://www.tannerhelland.com/4435/convert-temperature-rgb-algorithm-code/
+"""
+
+import math
+
+# Aproximate colour temperatures for common lighting conditions.
+COLOR_TEMPERATURES={
+    'candle':1900,
+    'sunrise':2000,
+    'incandescent':2500,
+    'tungsten':3200,
+    'halogen':3350,
+    'sunlight':5000,
+    'overcast':6000,
+    'shade':7000,
+    'blue-sky':10000
+}
+
+def correct_output(luminosity):
+    """
+    :param luminosity: Input luminosity
+    :return: Luminosity limited to the 0 <= l <= 255 range.
+    """
+    if luminosity < 0:
+        val = 0
+    elif luminosity > 255:
+        val = 255
+    else:
+        val = luminosity
+    return round(val)
+
+def kelvin_to_rgb(kelvin):
+    """
+    Convert a color temperature given in kelvin to an approximate RGB value.
+
+    :param kelvin: Color temp in K
+    :return: Tuple of (r, g, b), equivalent color for the temperature
+    """
+    temp = kelvin / 100
+
+    # Calculate Red:
+    if temp <= 66:
+        red = 255
+    else:
+        red = 329.698727446 * ((temp - 60) ** -0.1332047592)
+
+    # Calculate Green:
+
+    if temp <= 66:
+        green = 99.4708025861 * math.log(temp) - 161.1195681661
+    else:
+        green = 288.1221695283 * ((temp - 60) ** -0.0755148492)
+
+    #Calculate Blue:
+    if temp > 66:
+        blue = 255
+    elif temp <= 19:
+        blue = 0
+    else:
+        blue = 138.5177312231 * math.log(temp - 10) - 305.0447927307
+
+    return tuple(correct_output(c) for c in (red, green, blue))

--- a/python/pypi/blink1/shine.py
+++ b/python/pypi/blink1/shine.py
@@ -4,8 +4,9 @@ from blink1.blink1 import blink1
 
 @click.command()
 @click.option('--color', default='white', help='What colour to set the Blink(1)')
-def shine(color):
-    with blink1(False) as b1:
+@click.option('--white_point', default='incandescent', help='The name of the white-point to use')
+def shine(color, white_point):
+    with blink1(switch_off=False, white_point=white_point) as b1:
         b1.fade_to_color(100, color)
 
 

--- a/python/pypi/blink1_tests/test_b1_context_manager.py
+++ b/python/pypi/blink1_tests/test_b1_context_manager.py
@@ -1,6 +1,8 @@
 import unittest
+import time
 
 from blink1.blink1 import blink1
+from blink1.kelvin import COLOR_TEMPERATURES
 
 
 class TestBlink1ContextManager(unittest.TestCase):
@@ -16,6 +18,22 @@ class TestBlink1ContextManager(unittest.TestCase):
     def test_cm_with_gamma(self):
         with blink1(gamma=(.5, .5, .5)) as b1:
             b1.fade_to_color(0, "teal")
+
+    def test_cm_with_white_point(self):
+        with blink1(white_point=(255, 255, 255)) as b1:
+            b1.fade_to_color(0, "white")
+            time.sleep(0.1)
+
+    def test_cm_with_white_point(self):
+        with blink1(white_point=COLOR_TEMPERATURES['candle']) as b1:
+            b1.fade_to_color(0, "white")
+            time.sleep(0.1)
+
+    def test_cm_with_white_point(self):
+        with blink1(white_point='blue-sky') as b1:
+            b1.fade_to_color(0, "white")
+            time.sleep(0.1)
+
 
 
 if __name__ == '__main__':

--- a/python/pypi/blink1_tests/test_gamma.py
+++ b/python/pypi/blink1_tests/test_gamma.py
@@ -1,13 +1,13 @@
 import unittest
 import math
 import mock
-from blink1.blink1 import Gamma
+from blink1.blink1 import ColorCorrect
 
 
 class TestGamma(unittest.TestCase):
 
     def testUnity(self):
-        g = Gamma(1,1,1)
+        g = ColorCorrect(gamma=(1,1,1), white_point=(255,255,255))
         self.assertEquals(
             g(255,255,255),
             (255,255,255)
@@ -15,7 +15,7 @@ class TestGamma(unittest.TestCase):
 
     def testFullPowerHalfGamma(self):
         expected = round(255 * (1 ** 0.5))
-        g = Gamma(0.5,0.5,0.5)
+        g = ColorCorrect(gamma=(0.5,0.5,0.5), white_point=(255,255,255))
         self.assertEquals(
             g(255,255,255),
             (expected,expected,expected)
@@ -23,7 +23,7 @@ class TestGamma(unittest.TestCase):
 
     def testHalfPowerHalfGamma(self):
         expected = round(255 * (127 / 255) ** 0.5)
-        g = Gamma(0.5,0.5,0.5)
+        g = ColorCorrect(gamma=(0.5,0.5,0.5), white_point=(255,255,255))
         self.assertEquals(
             g(127,127,127),
             (expected,expected,expected)

--- a/python/pypi/blink1_tests/test_kelvin.py
+++ b/python/pypi/blink1_tests/test_kelvin.py
@@ -1,0 +1,34 @@
+import unittest
+import math
+import mock
+import time
+from blink1.kelvin import kelvin_to_rgb
+from blink1.blink1 import blink1
+
+
+class TestGamma(unittest.TestCase):
+
+    def test_red_6000(self):
+        r, g, b = kelvin_to_rgb(6000)
+        self.assertEquals(r, 255)
+
+    def test_blue_6700(self):
+        r, g, b = kelvin_to_rgb(6700)
+        self.assertEquals(b, 255)
+
+    def test_range(self):
+        """Verify that it is possible to produce the entire color range"""
+
+        for k in range(10, 12000, 400):
+            r,g,b = kelvin_to_rgb(k)
+            self.assertIsInstance(r, int)
+            self.assertIsInstance(g, int)
+            self.assertIsInstance(b, int)
+
+            with blink1(white_point=(r,g,b)) as b1:
+                b1.fade_to_color(0, 'white')
+                time.sleep(0.05)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/python/pypi/setup.py
+++ b/python/pypi/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup
 import os
 
 PROJECT_ROOT, _ = os.path.split(__file__)
-REVISION = '0.0.10'
+REVISION = '0.0.11'
 PROJECT_NAME = 'blink1'
 PROJECT_AUTHORS = "Salim Fadhley"
 PROJECT_EMAILS = 'salimfadhley@gmail.com'


### PR DESCRIPTION
The context-manager and Blink(1) class now support an additional 'white_point' argument. This can be a color_temp in K, a tuple of (r,g,b) or a named lighting situation (e.g. overcast, candle, tungsten). If names are chosen these are converted to approximate kelvin values and then to RGB.
