### PR TITLE
Corrected get_serial_number call & added close().

### DIFF
--- a/python/pypi/blink1_demo/demo1.py
+++ b/python/pypi/blink1_demo/demo1.py
@@ -18,7 +18,7 @@ if ( blink1.dev == None ):
 else:
     print("blink(1) found")
 
-print("serial number: " + blink1.get_serialnumber())
+print("serial number: " + blink1.get_serial_number())
 print("firmware version: " + blink1.get_version())
 
 print("fading to #ffffff")
@@ -28,5 +28,8 @@ time.sleep(0.5)
 
 print("fading to #000000")
 blink1.fade_to_rgb(1000, 0, 0, 0)
+
+print("closing connection to blink(1)")
+blink1.close()
 
 print("done")


### PR DESCRIPTION
It doesn't look like the call to close is needed currently but I thought it might be better to include it as a suggested practice just in case it eventually does more.
