### PR TITLE
Patching hiddata.c to claim the usb interface before sending control mes...

### DIFF
--- a/go/GoBlink/hiddata.c
+++ b/go/GoBlink/hiddata.c
@@ -75,12 +75,31 @@ static int          didUsbInit = 0;
             if(dev->descriptor.idVendor == vendor && dev->descriptor.idProduct == product){
                 char    string[256];
                 int     len;
+                int     detachrc;
+                char    drivername[2];
                 handle = usb_open(dev); /* we need to open the device in order to query strings */
                 if(!handle){
                     errorCode = USBOPEN_ERR_ACCESS;
                     fprintf(stderr, "Warning: cannot open USB device: %s\n", usb_strerror());
                     continue;
                 }
+
+#ifdef linux
+                // Likely no need to capture the return code.  It will return an error if no driver is
+                // attached, which is A-OK.  Nothing will be detached in that case.
+                usb_get_driver_np(handle, 0, drivername, sizeof(drivername));
+
+                // If we have an empty then nothing is attached, otherwise will be something like "dummy".
+                if(strlen(drivername) > 0){
+                    // Not doing this causes several issues writing control messages to the interface.
+                    detachrc = usb_detach_kernel_driver_np(handle, 0);
+                    if (detachrc != 0) {
+                        errorCode = USBOPEN_ERR_IO;
+                        fprintf(stderr, "Warning: cannot detach kernel driver from interface 0: %s\n", usb_strerror());
+                        continue;
+                    }
+                }
+#endif
                 if(vendorName == NULL && productName == NULL){  /* name does not matter */
                     break;
                 }
@@ -133,6 +152,7 @@ void    usbhidCloseDevice(usbDevice_t *device)
 int usbhidSetReport(usbDevice_t *device, char *buffer, int len)
 {
 int bytesSent, reportId = buffer[0];
+int claimrc, releaserc;
 
     if(!usesReportIDs){
         buffer++;   /* skip dummy report ID */
@@ -142,12 +162,29 @@ int bytesSent, reportId = buffer[0];
     //    bytesSent = usb_control_msg((void *)device, USB_TYPE_CLASS | USB_RECIP_DEVICE | USB_ENDPOINT_OUT, USBRQ_HID_SET_REPORT, USB_HID_REPORT_TYPE_FEATURE << 8 | (reportId & 0xff), 0, buffer, len, 5000);
     // modification by todbot, matches roughly what hiddata does
     // change by tod to use USB_RECIP_INTERFACE instead of USB_RECIP_DEVICE
+    claimrc = usb_claim_interface((void *)device, 0);
+    if(claimrc != 0){
+        fprintf(stderr, "Error claiming interface 0 before sending a control message: %s\n", usb_strerror());
+        return USBOPEN_ERR_IO;
+    }
+
     bytesSent = usb_control_msg((void *)device, USB_TYPE_CLASS | USB_RECIP_INTERFACE | USB_ENDPOINT_OUT, USBRQ_HID_SET_REPORT, USB_HID_REPORT_TYPE_FEATURE << 8 | (reportId & 0xff), 0, buffer, len, 5000);
     if(bytesSent != len){
         if(bytesSent < 0)
             fprintf(stderr, "Error sending message: %s\n", usb_strerror());
+
+        // Ehhh
+        usb_release_interface((void *)device, 0);
+
         return USBOPEN_ERR_IO;
     }
+
+    releaserc = usb_release_interface((void *)device, 0);
+    if(claimrc != 0){
+        fprintf(stderr, "Error releasing interface 0 after sending a control message: %s\n", usb_strerror());
+        return USBOPEN_ERR_IO;
+    }
+
     return 0;
 }
 
@@ -156,6 +193,7 @@ int bytesSent, reportId = buffer[0];
 int usbhidGetReport(usbDevice_t *device, int reportNumber, char *buffer, int *len)
 {
 int bytesReceived, maxLen = *len;
+int claimrc, releaserc;
 
     if(!usesReportIDs){
         buffer++;   /* make room for dummy report ID */
@@ -164,9 +202,19 @@ int bytesReceived, maxLen = *len;
     // original hiddata.h
     //bytesReceived = usb_control_msg((void *)device, USB_TYPE_CLASS | USB_RECIP_DEVICE | USB_ENDPOINT_IN, USBRQ_HID_GET_REPORT, USB_HID_REPORT_TYPE_FEATURE << 8 | reportNumber, 0, buffer, maxLen, 5000);
     // change by tod to use USB_RECIP_INTERFACE instead of USB_RECIP_DEVICE
+
+    claimrc = usb_claim_interface((void *)device, 0);
+    if(claimrc != 0){
+        fprintf(stderr, "Error claiming interface 0 before sending a control message: %s\n", usb_strerror());
+        return USBOPEN_ERR_IO;
+    }
+
     bytesReceived = usb_control_msg((void *)device, USB_TYPE_CLASS | USB_RECIP_INTERFACE | USB_ENDPOINT_IN, USBRQ_HID_GET_REPORT, USB_HID_REPORT_TYPE_FEATURE << 8 | reportNumber, 0, buffer, maxLen, 5000);
     if(bytesReceived < 0){
         fprintf(stderr, "Error sending message: %s\n", usb_strerror());
+
+        usb_release_interface((void *)device, 0);
+
         return USBOPEN_ERR_IO;
     }
     *len = bytesReceived;
@@ -174,5 +222,12 @@ int bytesReceived, maxLen = *len;
         buffer[-1] = reportNumber;  /* add dummy report ID */
         (*len)++;
     }
+
+    releaserc = usb_release_interface((void *)device, 0);
+    if(claimrc != 0){
+        fprintf(stderr, "Error releasing interface 0 after sending a control message: %s\n", usb_strerror());
+        return USBOPEN_ERR_IO;
+    }
+
     return 0;
 }


### PR DESCRIPTION
Hello,

Executing the golang example under linux resulted in the following errors:

```
Error sending message: Input/output error
2014/07/25 01:05:40 error writing data: Communication error with device
```

And these entries in /var/log/messages:

```
Jul 25 01:05:40 localhost kernel: [ 2220.123509] usb 2-2.1: usbfs: process 5064 (goBlink) did not claim interface 0 before use
Jul 25 01:05:40 localhost kernel: usb 2-2.1: usbfs: process 5064 (goBlink) did not claim interface 0 before use
```

It seems like Linux in particular needs first to detach the kernel driver from the interface before claiming it.

The example seems to work great after these changes.  I don't have access to an OS X machine to verify that things still work under that environment.
