### PR TITLE
make random more random

### DIFF
--- a/commandline/blink1-mini-tool/blink1-mini-tool.c
+++ b/commandline/blink1-mini-tool/blink1-mini-tool.c
@@ -18,6 +18,7 @@
 #include <string.h>    // for memset() et al
 #include <stdint.h>    // for uint8_t
 #include <unistd.h>    // for usleep()
+#include <time.h>      // for time()
 
 #include "hiddata.h"
 
@@ -111,6 +112,7 @@ int main(int argc, char **argv)
         } else {
             hexread(argbuf, argv[2], sizeof(argbuf));
         }
+        srand(time(NULL) * getpid()); // feed the random number generator
         for( int i=0; i<argbuf[0]; i++ ) { 
             uint8_t r = rand()%255;
             uint8_t g = rand()%255;

--- a/commandline/blink1-tool.c
+++ b/commandline/blink1-tool.c
@@ -33,6 +33,9 @@
 #define BLINK1_VERSION "v0.0"
 #endif
 
+#ifdef _WIN32
+#define getpid _getpid
+#endif
 
 int millis = 300;
 int delayMillis = 500;
@@ -248,8 +251,7 @@ int main(int argc, char** argv)
     uint8_t tmpbuf[100];
     char serialnumstr[serialstrmax] = {'\0'}; 
 
-    uint16_t seed = time(NULL);
-    srand(seed);
+    srand( time(NULL) * getpid() );
     memset( cmdbuf, 0, sizeof(cmdbuf));
 
     static int cmd  = CMD_NONE;

--- a/commandline/blink1control-tool/blink1control-tool.c
+++ b/commandline/blink1control-tool/blink1control-tool.c
@@ -387,8 +387,7 @@ int main(int argc, char** argv)
     uint8_t tmpbuf[100];
     //char serialnumstr[serialstrmax] = {'\0'}; 
 
-    uint16_t seed = time(NULL);
-    srand(seed);
+    srand( time(NULL) * getpid() );
     memset( cmdbuf, 0, sizeof(cmdbuf));
 
     static int cmd  = CMD_NONE;


### PR DESCRIPTION
The commandline tools now initialize their random seed (srand()) with more entropy through getpid(). When called twice in a second the colors didn't change. This is fixed now.
