### PR TITLE
Feature/clean ups

### DIFF
--- a/qt/.gitignore
+++ b/qt/.gitignore
@@ -1,0 +1,1 @@
+/build-blink1control-Desktop-Debug/

--- a/qt/blink1control/mainwindow.cpp
+++ b/qt/blink1control/mainwindow.cpp
@@ -98,6 +98,7 @@ MainWindow::MainWindow(QWidget *parent) :
     logstream=NULL;
     mode = NONE;
     duplicateCounter=0; // FIXME: bad name for this var
+    refreshCounter = 0;
 
     osFixes();
     


### PR DESCRIPTION
Two tiny tweaks in one PR.
Valgrind through up a use-before-assign error with refreshCounter and my git client's spam about the build directory was bugging me, so I've fixed both.