### PR TITLE
Reset static_dev to NULL

### DIFF
--- a/commandline/blink1-lib-lowlevel-hiddata.h
+++ b/commandline/blink1-lib-lowlevel-hiddata.h
@@ -154,6 +154,7 @@ blink1_device* blink1_open(void)
     LOG("blink1_open\n");
     if( rc != USBOPEN_SUCCESS ) { 
         LOG("cannot open: \n");
+        static_dev = NULL;
     }
     return static_dev;
 }


### PR DESCRIPTION
Reset static_dev to NULL when blink1_open() fails.  This prevents
a use after free and a potential crash.

Without this fix I get an bus error on OpenBSD when I pull the
blink(1) device from the USB slot while blink1-tool --blink is
running.
