### PR TITLE
Replace sprintf() and strcpy() with snprintf() and strncpy().

### DIFF
--- a/commandline/blink1-lib-lowlevel-hidapi.h
+++ b/commandline/blink1-lib-lowlevel-hidapi.h
@@ -20,8 +20,10 @@ int blink1_enumerateByVidPid(int vid, int pid)
         if( (cur_dev->vendor_id != 0 && cur_dev->product_id != 0) &&  
             (cur_dev->vendor_id == vid && cur_dev->product_id == pid) ) { 
             if( cur_dev->serial_number != NULL ) { // can happen if not root
-                strcpy( blink1_infos[p].path,   cur_dev->path );
-                sprintf( blink1_infos[p].serial, "%ls", cur_dev->serial_number);
+                strncpy( blink1_infos[p].path, cur_dev->path,
+                    sizeof(blink1_infos[p].path));
+                snprintf(blink1_infos[p].serial, sizeof(blink1_infos[p].serial),
+                    "%ls", cur_dev->serial_number);
                 //wcscpy( blink1_infos[p].serial, cur_dev->serial_number );
                 //uint32_t sn = wcstol( cur_dev->serial_number, NULL, 16);
                 uint32_t serialnum = strtol( blink1_infos[p].serial, NULL, 16);
@@ -104,7 +106,7 @@ blink1_device* blink1_openById( uint32_t i )
     LOG("blink1_openById: %d \n", i );
     if( i > blink1_max_devices ) { // then i is a serial number not an array index
         char serialstr[serialstrmax];
-        sprintf( serialstr, "%X", i);  // convert to wchar_t* 
+        snprintf(serialstr, sizeof(serialstr), "%X", i); // convert to wchar_t*
         return blink1_openBySerial( serialstr );  
     } 
     else {
@@ -189,7 +191,7 @@ char *blink1_error_msg(int errCode)
         case USBOPEN_ERR_NOTFOUND:  return "The specified device was not found";
         case USBOPEN_ERR_IO:        return "Communication error with device";
         default:
-            sprintf(buf, "Unknown USB error %d", errCode);
+            snprintf(buf, sizeof(buf), "Unknown USB error %d", errCode);
             return buf;
     }
     */

--- a/commandline/blink1-lib-lowlevel-hiddata.h
+++ b/commandline/blink1-lib-lowlevel-hiddata.h
@@ -15,7 +15,7 @@ char *blink1_error_msg(int errCode)
         case USBOPEN_ERR_NOTFOUND:  return "The specified device was not found";
         case USBOPEN_ERR_IO:        return "Communication error with device";
         default:
-            sprintf(buffer, "Unknown USB error %d", errCode);
+            snprintf(buffer, sizeof(buffer), "Unknown USB error %d", errCode);
             return buffer;
     }
     return NULL;    /* not reached */
@@ -46,8 +46,10 @@ int blink1_enumerateByVidPid(int vid, int pid)
         if( (cur_dev->vendor_id != 0 && cur_dev->product_id != 0) &&  
             (cur_dev->vendor_id == vid && cur_dev->product_id == pid) ) { 
             if( cur_dev->serial_number != NULL ) { // can happen if not root
-                strcpy( blink1_infos[p].path,   cur_dev->path );
-                sprintf( blink1_infos[p].serial, "%ls", cur_dev->serial_number);
+                strncpy( blink1_infos[p].path, cur_dev->path,
+                    sizeof(blink1_infos[p].path));
+                snprintf(blink1_infos[p].serial, sizeof(blink1_infos[p].serial),
+                    "%ls", cur_dev->serial_number);
                 //wcscpy( blink1_infos[p].serial, cur_dev->serial_number );
                 //uint32_t sn = wcstol( cur_dev->serial_number, NULL, 16);
                 uint32_t serialnum = strtol( blink1_infos[p].serial, NULL, 16);
@@ -136,7 +138,7 @@ blink1_device* blink1_openById( uint32_t i )
 { 
     if( i > blink1_max_devices ) { // then i is a serial number not array index
         char serialstr[serialstrmax];
-        sprintf( serialstr, "%X", i);  // convert to wchar_t* 
+        snprintf(serialstr, sizeof(serialstr), "%X", i); // convert to wchar_t*
         return blink1_openBySerial( serialstr );  
     } 
     else {

--- a/commandline/blink1-lib.c
+++ b/commandline/blink1-lib.c
@@ -102,7 +102,7 @@ int blink1_getCacheIndexById( uint32_t i )
 {
     if( i > blink1_max_devices ) { // then i is a serial number not an array index
         char serialstr[serialstrmax];
-        sprintf( serialstr, "%X", i);  // convert to wchar_t* 
+        snprintf(serialstr, sizeof(serialstr), "%X", i); // convert to wchar_t*
         return blink1_getCacheIndexBySerial( serialstr );
     }
     return i;

--- a/commandline/blink1-tool.c
+++ b/commandline/blink1-tool.c
@@ -510,7 +510,7 @@ int main(int argc, char** argv)
             dev = blink1_openById( deviceIds[0] );
             rc = blink1_getVersion(dev);
             blink1_close(dev);
-            sprintf(verbuf, ", fw version: %d", rc);
+            snprintf(verbuf, sizeof(verbuf), ", fw version: %d", rc);
         }
         msg("blink1-tool version: %s%s\n",BLINK1_VERSION,verbuf);
         exit(0);
@@ -742,7 +742,8 @@ int main(int argc, char** argv)
             do_rand =1;
         }
         char ledstr[16];
-        sprintf(ledstr, "#%2.2x%2.2x%2.2x", rgbbuf.r,rgbbuf.g,rgbbuf.b);
+        snprintf(ledstr, sizeof(ledstr), "#%2.2x%2.2x%2.2x",
+            rgbbuf.r,rgbbuf.g,rgbbuf.b);
         msg("chase effect %d to %d (with %d leds), color %s, ",
             led_start, led_end, chase_length,
             ((do_rand) ? "random" : ledstr));


### PR DESCRIPTION
Replace sprintf() and strcpy() with snprintf() and strncpy(). This
avoids linker warnings and you do not have to care about possible
buffer overflows.

On OpenBSD using unsafe string functions create linker warnings.
Althoug there may be no overflow when used here, it is cleaner and
trivial to prevent it by using the safe functions.