### PR TITLE
Fix Broken '-l 0' While Writing Pattern Line via blink1-tool

### DIFF
--- a/commandline/blink1-tool.c
+++ b/commandline/blink1-tool.c
@@ -675,7 +675,7 @@ int main(int argc, char** argv)
         uint8_t b = rgbbuf.b;
         uint8_t p = cmdbuf[0];
         msg("saving rgb: 0x%2.2x,0x%2.2x,0x%2.2x @ %d, ms:%d\n",r,g,b,p,millis);
-        if( ledn>0 ) { // NOTE: only works for unreleased mk2a
+        if( ledn>=0 ) { // NOTE: only works for unreleased mk2a
             blink1_setLEDN(dev, ledn);  // FIXME: doesn't check return code
         }
         rc = blink1_writePatternLine(dev, millis, r,g,b, p );


### PR DESCRIPTION
While using `-l` with `--setpattline` of **blink1-tool** to write pattern lines, I noticed that only `-l 1` or `-l 2` works but `-l 0` doesn't, it means that once LED1 or LED2 is separately set via **blink1-tool**, users can't set both LEDs with single pattern line via **blink1-tool**.

I used and tested on **blink(1) mk2** with:

| Tool | Version |
|:-----|:-----:|
| blink1-tool | v1.97-macosx-x86_64 |
| firmware | 204 |

P.S. My devices were purchased via [ThingM online store](http://buy.thingm.com/blink1), and the order number was AB-3675. So they must be released version. But the HID instruction `'l'` works on them as well. Do you think that comments like `NOTE: only works for unreleased mk2a` should be removed?

Commands to repro the bug:
```bash
# Set pattern lines
./blink1-tool -m 500 --blue -l 1 --setpattline 0
./blink1-tool -m 500 --blue -l 2 --setpattline 1
./blink1-tool -m 500 --off --setpattline 2
./blink1-tool -m 500 --red --setpattline 3
./blink1-tool -m 500 --off -l 1 --setpattline 4
./blink1-tool -m 500 --off -l 2 --setpattline 5

# Reset unused pattern lines
for ((i=6;i<16;i++)) do
  ./blink1-tool -m 0 --off --setpattline $i;
done

# Play
./blink1-tool --play 1,0

# Stop
./blink1-tool --off
```

Demonstration (.gif files might be slow to load):

| Actual/Before | Expected/After |
|:-----:|:-----:|
| ![actual clip](https://cloud.githubusercontent.com/assets/2491781/13553297/9b837306-e3bf-11e5-838b-81b4180936c9.gif) | ![expected clip](https://cloud.githubusercontent.com/assets/2491781/13553298/b0a442d8-e3bf-11e5-8abc-55155edc3e01.gif) |

Another way to repro the bug is to rewrite the default [`patternflash`](https://github.com/todbot/blink1/blob/master/hardware/firmware_mk2/main.c#L166-L185) via **blink1-tool**. Here's my version and it works differently without the fix:

```bash
./blink1-tool -m 500 --rgb 0xff,0x00,0x00 -l 1 --setpattline 0
./blink1-tool -m 500 --rgb 0xff,0x00,0x00 -l 2 --setpattline 1
./blink1-tool -m 500 --rgb 0x00,0x00,0x00 -l 0 --setpattline 2
./blink1-tool -m 500 --rgb 0x00,0xff,0x00 -l 1 --setpattline 3
./blink1-tool -m 500 --rgb 0x00,0xff,0x00 -l 2 --setpattline 4
./blink1-tool -m 500 --rgb 0x00,0x00,0x00 -l 0 --setpattline 5
./blink1-tool -m 500 --rgb 0x00,0x00,0xff -l 1 --setpattline 6
./blink1-tool -m 500 --rgb 0x00,0x00,0xff -l 2 --setpattline 7
./blink1-tool -m 500 --rgb 0x00,0x00,0x00 -l 0 --setpattline 8
./blink1-tool -m 1000 --rgb 0x80,0x80,0x80 -l 0 --setpattline 9
./blink1-tool -m 1000 --rgb 0x00,0x00,0x00 -l 0 --setpattline 10
./blink1-tool -m 500 --rgb 0xff,0xff,0xff -l 1 --setpattline 11
./blink1-tool -m 500 --rgb 0x00,0x00,0x00 -l 1 --setpattline 12
./blink1-tool -m 500 --rgb 0xff,0xff,0xff -l 2 --setpattline 13
./blink1-tool -m 1000 --rgb 0x00,0x00,0x00 -l 2 --setpattline 14
./blink1-tool -m 1000 --rgb 0x00,0x00,0x00 -l 0 --setpattline 15
```
