### PR TITLE
Improve Code Quality and Readability of ManagedBlink1

### DIFF
--- a/windows/ManagedBlink1/Blink1.ColorPicker/AssemblyInfo.cs
+++ b/windows/ManagedBlink1/Blink1.ColorPicker/AssemblyInfo.cs
@@ -1,5 +1,4 @@
 using System.Reflection;
-using System.Runtime.CompilerServices;
 
 //
 // General Information about an assembly is controlled through the following 

--- a/windows/ManagedBlink1/Blink1.ColorPicker/ColorManager.cs
+++ b/windows/ManagedBlink1/Blink1.ColorPicker/ColorManager.cs
@@ -1,16 +1,13 @@
 using System;
 using System.Drawing;
-using System.Collections;
 using System.ComponentModel;
 using System.Windows.Forms;
 
 namespace ThingM.Blink1.ColorManager
 {
     using System.Collections.Generic;
-    using System.Dynamic;
     using System.IO;
     using System.Linq;
-    using System.Net;
     using System.Xml.Linq;
 
     using ThingM.Blink1;

--- a/windows/ManagedBlink1/Blink1.ColorPicker/ColorWheel.cs
+++ b/windows/ManagedBlink1/Blink1.ColorPicker/ColorWheel.cs
@@ -520,7 +520,7 @@ namespace ThingM.Blink1.ColorManager
         {
             // Given the center of a circle and its radius, along
             // with the angle corresponding to the point, find the coordinates. 
-            // In other words, conver  t from polar to rectangular coordinates.
+            // In other words, convert from polar to rectangular coordinates.
             double radians = degrees / DEGREES_PER_RADIAN;
 
             return new Point((int)(centerPoint.X + Math.Floor(radius * Math.Cos(radians))), (int)(centerPoint.Y - Math.Floor(radius * Math.Sin(radians))));

--- a/windows/ManagedBlink1/Blink1.ColorPicker/Main.cs
+++ b/windows/ManagedBlink1/Blink1.ColorPicker/Main.cs
@@ -1,9 +1,4 @@
-using System;
-using System.Drawing;
-using System.Collections;
-using System.ComponentModel;
 using System.Windows.Forms;
-using System.Data;
 
 namespace ColorChooserCSharp
 {

--- a/windows/ManagedBlink1/Blink1.ColorPicker/PresetControl.cs
+++ b/windows/ManagedBlink1/Blink1.ColorPicker/PresetControl.cs
@@ -1,11 +1,5 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.ComponentModel;
-using System.Drawing;
-using System.Data;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using System.Windows.Forms;
 
 namespace ThingM.Blink1.ColorManager

--- a/windows/ManagedBlink1/Blink1.ColorPicker/Program.cs
+++ b/windows/ManagedBlink1/Blink1.ColorPicker/Program.cs
@@ -1,13 +1,8 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
 using System.Windows.Forms;
 
 namespace ThingM.Blink1.ColorManager
 {
-    using ColorChooserCSharp;
-
     static class Program
     {
         /// <summary>

--- a/windows/ManagedBlink1/Blink1.ConsoleDemo/Program.cs
+++ b/windows/ManagedBlink1/Blink1.ConsoleDemo/Program.cs
@@ -30,6 +30,24 @@ namespace ThingM.Blink1.ConsoleDemo
         /// The arguments.
         /// </param>
         public static void Main(string[] args)
+        {          
+            TestCase1();
+            TestCase2();
+            TestCase3();
+            TestCase4();
+            TestCase5();
+            TestCase6();
+            TestCase7();
+            TestCase8();
+
+            Console.WriteLine("We're done with the demo, press any key to stop the program.");
+            Console.ReadKey();
+        }
+
+        /// <summary>
+        ///     Pass 1: work on the first Blink(1) device found, synchronously
+        /// </summary>
+        private static void TestCase1()
         {
             Console.WriteLine("####################################################################");
             Console.WriteLine("## Pass 1: work on the first Blink(1) device found, synchronously ##");
@@ -48,20 +66,26 @@ namespace ThingM.Blink1.ConsoleDemo
             blink1.SetColor(255, 0, 0);
 
             Console.WriteLine("Pass 1: Set Blink(1) to fade to BLUE over 10 seconds.");
-            blink1.FadeToColor(3000, 0, 0, 255, false);
+            blink1.FadeToColor(10000, 0, 0, 255, false);
 
             Console.WriteLine("Pass 1: Closing Blink(1) connection.");
             blink1.Close();
 
             Console.WriteLine(Environment.NewLine);
+        }
 
+        /// <summary>
+        ///     Pass 2: work on the last Blink(1) device found, asynchronously
+        /// </summary>
+        private static void TestCase2()
+        {
             Console.WriteLine("####################################################################");
             Console.WriteLine("## Pass 2: work on the last Blink(1) device found, asynchronously ##");
             Console.WriteLine("####################################################################");
 
             List<string> devicePaths = Blink1Info.GetDevicePath();
 
-            blink1 = new Blink1();
+            Blink1 blink1 = new Blink1();
 
             Console.WriteLine("Pass 2: Opening the last Blink(1) found via its HID path.");
             blink1.Open(devicePaths.Last());
@@ -111,13 +135,19 @@ namespace ThingM.Blink1.ConsoleDemo
             blink1.Close();
 
             Console.WriteLine(Environment.NewLine);
+        }
 
+        /// <summary>
+        ///     Pass 3: reading the current presets
+        /// </summary>
+        private static void TestCase3()
+        {
             Console.WriteLine("#########################################");
             Console.WriteLine("## Pass 3: reading the current presets ##");
             Console.WriteLine("#########################################");
 
             // Note, any dealing with presets is done asynchronously.
-            blink1 = new Blink1();
+            Blink1 blink1 = new Blink1();
 
             Console.WriteLine("Pass 3: Opening the first Blink(1) found.");
             blink1.Open();
@@ -134,12 +164,18 @@ namespace ThingM.Blink1.ConsoleDemo
             blink1.Close();
 
             Console.WriteLine(Environment.NewLine);
+        }
 
+        /// <summary>
+        ///     Pass 4: playing the current presets
+        /// </summary>
+        private static void TestCase4()
+        {
             Console.WriteLine("#########################################");
             Console.WriteLine("## Pass 4: playing the current presets ##");
             Console.WriteLine("#########################################");
 
-            blink1 = new Blink1();
+            Blink1 blink1 = new Blink1();
 
             Console.WriteLine("Pass 4: Opening the first Blink(1) found.");
             blink1.Open();
@@ -155,12 +191,18 @@ namespace ThingM.Blink1.ConsoleDemo
             blink1.Close();
 
             Console.WriteLine(Environment.NewLine);
+        }
 
+        /// <summary>
+        ///     Pass 5: saving new random presets
+        /// </summary>
+        private static void TestCase5()
+        {
             Console.WriteLine("#######################################");
             Console.WriteLine("## Pass 5: saving new random presets ##");
             Console.WriteLine("#######################################");
 
-            blink1 = new Blink1();
+            Blink1 blink1 = new Blink1();
 
             Console.WriteLine("Pass 5: Opening the first Blink(1) found.");
             blink1.Open();
@@ -178,12 +220,18 @@ namespace ThingM.Blink1.ConsoleDemo
             blink1.Close();
 
             Console.WriteLine(Environment.NewLine);
+        }
 
+        /// <summary>
+        ///     Pass 6: reading the new random presets
+        /// </summary>
+        private static void TestCase6()
+        {
             Console.WriteLine("############################################");
             Console.WriteLine("## Pass 6: reading the new random presets ##");
             Console.WriteLine("############################################");
 
-            blink1 = new Blink1();
+            Blink1 blink1 = new Blink1();
 
             Console.WriteLine("Pass 6: Opening the first Blink(1) found.");
             blink1.Open();
@@ -200,12 +248,18 @@ namespace ThingM.Blink1.ConsoleDemo
             blink1.Close();
 
             Console.WriteLine(Environment.NewLine);
+        }
 
+        /// <summary>
+        ///     Pass 7: playing the new random presets
+        /// </summary>
+        private static void TestCase7()
+        {
             Console.WriteLine("############################################");
             Console.WriteLine("## Pass 7: playing the new random presets ##");
             Console.WriteLine("############################################");
 
-            blink1 = new Blink1();
+            Blink1 blink1 = new Blink1();
 
             Console.WriteLine("Pass 7: Opening the first Blink(1) found.");
             blink1.Open();
@@ -221,12 +275,18 @@ namespace ThingM.Blink1.ConsoleDemo
             blink1.Close();
 
             Console.WriteLine(Environment.NewLine);
+        }
 
+        /// <summary>
+        ///     Pass 8: work with the inactivity mode
+        /// </summary>
+        private static void TestCase8()
+        {
             Console.WriteLine("###########################################");
             Console.WriteLine("## Pass 8: work with the inactivity mode ##");
             Console.WriteLine("###########################################");
 
-            blink1 = new Blink1();
+            Blink1 blink1 = new Blink1();
 
             Console.WriteLine("Pass 8: Opening the first Blink(1) found.");
             blink1.Open();
@@ -264,8 +324,6 @@ namespace ThingM.Blink1.ConsoleDemo
             blink1.Close();
 
             Console.WriteLine(Environment.NewLine);
-            Console.WriteLine("We're done with the demo, press any key to stop the program.");
-            Console.ReadKey();
         }
 
         #endregion

--- a/windows/ManagedBlink1/Blink1.ConsoleDemo/Program.cs
+++ b/windows/ManagedBlink1/Blink1.ConsoleDemo/Program.cs
@@ -30,7 +30,7 @@ namespace ThingM.Blink1.ConsoleDemo
         /// The arguments.
         /// </param>
         public static void Main(string[] args)
-        {          
+        {
             TestCase1();
             TestCase2();
             TestCase3();
@@ -67,6 +67,7 @@ namespace ThingM.Blink1.ConsoleDemo
 
             Console.WriteLine("Pass 1: Set Blink(1) to fade to BLUE over 10 seconds.");
             blink1.FadeToColor(10000, 0, 0, 255, false);
+            Thread.Sleep(10000);
 
             Console.WriteLine("Pass 1: Closing Blink(1) connection.");
             blink1.Close();
@@ -157,7 +158,7 @@ namespace ThingM.Blink1.ConsoleDemo
                 Blink1Preset blink1Preset = blink1.ReadPreset(position);
 
                 Console.WriteLine(
-                    "Pass 3: Position:{0}, Millisecond:{1}, Red:{2}, Green:{3}, Blue:{4}", position, blink1Preset.Millisecond, blink1Preset.Rgb.Red, blink1Preset.Rgb.Green, blink1Preset.Rgb.Blue);
+                    "Pass 3: Position:{0,3}, Millisecond:{1,5}, Red:{2,4}, Green:{3,4}, Blue:{4,4}, Hex: #{2:X02}{3:X02}{4:X02}", position, blink1Preset.Millisecond, blink1Preset.Rgb.Red, blink1Preset.Rgb.Green, blink1Preset.Rgb.Blue);
             }
 
             Console.WriteLine("Pass 3: Closing Blink(1) connection.");
@@ -212,7 +213,7 @@ namespace ThingM.Blink1.ConsoleDemo
                 Blink1Preset blink1Preset = new Blink1Preset(Convert.ToUInt16(1000 + (position * 10)), GetRandomRgbColor());
 
                 Console.WriteLine(
-                    "Pass 5: Position:{0}, Millisecond:{1}, Red:{2}, Green:{3}, Blue:{4}", position, blink1Preset.Millisecond, blink1Preset.Rgb.Red, blink1Preset.Rgb.Green, blink1Preset.Rgb.Blue);
+                    "Pass 5: Position:{0,3}, Millisecond:{1,5}, Red:{2,4}, Green:{3,4}, Blue:{4,4}, Hex: #{2:X02}{3:X02}{4:X02}", position, blink1Preset.Millisecond, blink1Preset.Rgb.Red, blink1Preset.Rgb.Green, blink1Preset.Rgb.Blue);
                 blink1.SavePreset(blink1Preset, position);
             }
 
@@ -241,7 +242,7 @@ namespace ThingM.Blink1.ConsoleDemo
                 Blink1Preset blink1Preset = blink1.ReadPreset(position);
 
                 Console.WriteLine(
-                    "Pass 6: Position:{0}, Millisecond:{1}, Red:{2}, Green:{3}, Blue:{4}", position, blink1Preset.Millisecond, blink1Preset.Rgb.Red, blink1Preset.Rgb.Green, blink1Preset.Rgb.Blue);
+                    "Pass 6: Position:{0,3}, Millisecond:{1,5}, Red:{2,4}, Green:{3,4}, Blue:{4,4}, Hex: #{2:X02}{3:X02}{4:X02}", position, blink1Preset.Millisecond, blink1Preset.Rgb.Red, blink1Preset.Rgb.Green, blink1Preset.Rgb.Blue);
             }
 
             Console.WriteLine("Pass 6: Closing Blink(1) connection.");

--- a/windows/ManagedBlink1/Blink1.ConsoleDemo/Program.cs
+++ b/windows/ManagedBlink1/Blink1.ConsoleDemo/Program.cs
@@ -99,7 +99,7 @@ namespace ThingM.Blink1.ConsoleDemo
 
             Thread.Sleep(1000);
 
-            Console.WriteLine("Pass 1: Set Blink(1) to be BLACK.");
+            Console.WriteLine("Pass 2: Set Blink(1) to be BLACK.");
             blink1.SetColor(0, 0, 0);
 
             Thread.Sleep(1000);

--- a/windows/ManagedBlink1/Blink1/Blink1Constant.cs
+++ b/windows/ManagedBlink1/Blink1/Blink1Constant.cs
@@ -17,9 +17,11 @@ namespace ThingM.Blink1
         #region Constants
 
         /// <summary>
-        ///     The maximum number of presets supported by a Blink(1) device.
+        ///     The maximum number of presets supported by a Blink(1) device:
+        ///       1) for blink(1) mk1, 12 lines
+        ///       2) for blink(1) mk2, 32 lines  
         /// </summary>
-        public const int NumberOfPreset = 12;
+        public const int NumberOfPreset = 32;
 
         /// <summary>
         ///     The product id (493).

--- a/windows/ManagedBlink1/Blink1/ColorProcessor/Hsl.cs
+++ b/windows/ManagedBlink1/Blink1/ColorProcessor/Hsl.cs
@@ -63,7 +63,7 @@ namespace ThingM.Blink1.ColorProcessor
         #region Public Properties
 
         /// <summary>
-        ///     Gets or sets the hue component component of the color.
+        ///     Gets or sets the hue component of the color.
         /// </summary>
         public ushort Hue
         {

--- a/windows/ManagedBlink1/Blink1/ColorProcessor/HtmlColorName.cs
+++ b/windows/ManagedBlink1/Blink1/ColorProcessor/HtmlColorName.cs
@@ -17,7 +17,7 @@ namespace ThingM.Blink1.ColorProcessor
         #region Constants
 
         /// <summary>
-        /// The alice blue.
+        /// The Alice blue.
         /// </summary>
         public const string AliceBlue = "#F0F8FF";
 
@@ -212,7 +212,7 @@ namespace ThingM.Blink1.ColorProcessor
         public const string DarkViolet = "#9400D3";
 
         /// <summary>
-        /// The darkorange.
+        /// The dark orange.
         /// </summary>
         public const string Darkorange = "#FF8C00";
 
@@ -262,7 +262,7 @@ namespace ThingM.Blink1.ColorProcessor
         public const string Fuchsia = "#FF00FF";
 
         /// <summary>
-        /// The gainsboro.
+        /// The Gainsboro.
         /// </summary>
         public const string Gainsboro = "#DCDCDC";
 
@@ -312,7 +312,7 @@ namespace ThingM.Blink1.ColorProcessor
         public const string HotPink = "#FF69B4";
 
         /// <summary>
-        /// The indian red.
+        /// The Indian red.
         /// </summary>
         public const string IndianRed = "#CD5C5C";
 
@@ -517,7 +517,7 @@ namespace ThingM.Blink1.ColorProcessor
         public const string Moccasin = "#FFE4B5";
 
         /// <summary>
-        /// The navajo white.
+        /// The Navajo white.
         /// </summary>
         public const string NavajoWhite = "#FFDEAD";
 
@@ -587,7 +587,7 @@ namespace ThingM.Blink1.ColorProcessor
         public const string PeachPuff = "#FFDAB9";
 
         /// <summary>
-        /// The peru.
+        /// The Peru.
         /// </summary>
         public const string Peru = "#CD853F";
 

--- a/windows/ManagedBlink1/Blink1/ColorProcessor/HtmlHexadecimal.cs
+++ b/windows/ManagedBlink1/Blink1/ColorProcessor/HtmlHexadecimal.cs
@@ -94,7 +94,7 @@ namespace ThingM.Blink1.ColorProcessor
         /// Validate if the string format match the HTML hexadecimal #FFFFFF format.
         /// </summary>
         /// <param name="color">
-        /// The html color.
+        /// The HTML color.
         /// </param>
         /// <returns>
         /// True if the format is valid, false otherwise.

--- a/windows/ManagedBlink1/HidLibrary/HidDevices.cs
+++ b/windows/ManagedBlink1/HidLibrary/HidDevices.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.Linq;
 using System.Runtime.InteropServices;
 

--- a/windows/ManagedBlink1/HidLibrary/Properties/AssemblyInfo.cs
+++ b/windows/ManagedBlink1/HidLibrary/Properties/AssemblyInfo.cs
@@ -1,5 +1,4 @@
 ﻿using System.Reflection;
-using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
 // General Information about an assembly is controlled through the following 


### PR DESCRIPTION
The following improvements on ManagedBlink1 solution were made in this pull request:

* Remove unused 'using'
* Fix typo and misspelled words
* Improve readability of test cases in Blink1.ConsoleDemo
* Adjust const `NumberOfPreset` for mk2 device

If you want to modify/reject part of them, feel free to let me know.
