### PR TITLE
Fixed "The device does not support the specified langid" error

### DIFF
--- a/python/pypi/blink1/blink1.py
+++ b/python/pypi/blink1/blink1.py
@@ -201,7 +201,7 @@ class Blink1:
     def get_serial_number(self):
         """Get blink(1) serial number
         """
-        return usb.util.get_string(self.dev, 256, 3)
+        return usb.util.get_string(self.dev, 3)
 
 
 @contextmanager


### PR DESCRIPTION
In the latest PyUSB, usb.util.get_string no longer has a length argument (commit dac78933f6a6eaf5ae82f48e2f4e7d1733dc2f98) therefore it gets index as langid instead of None and fails.